### PR TITLE
Don't return null if the `x-app-rate-limit` header doesn't exist

### DIFF
--- a/src/KeyFinder.ts
+++ b/src/KeyFinder.ts
@@ -77,7 +77,16 @@ export default class KeyFinder {
             }
         });
 
-        return resp.status === 403 ? null : resp.headers.get("x-app-rate-limit");
+        // resp.headers.get("x-app-rate-limit") might return null
+        // if it is, just send the rate limit as 'unknown'
+        const rateLimit = resp.headers.get('x-app-rate-limit');
+        if (resp.status === 403) {
+            return null;
+        } else if (rateLimit) {
+            return rateLimit;
+        } else {
+            return 'unknown';
+        }
     }
 
     /**


### PR DESCRIPTION
This should fix the case where Botty is bamboozling us into thinking a key has been reset when there's a 500 error without an `x-app-rate-limit` header