### PR TITLE
allow notes to have other text after them 

### DIFF
--- a/src/Info.ts
+++ b/src/Info.ts
@@ -33,6 +33,7 @@ export default class Info {
 
     public onAll(message: Discord.Message, isAdmin: boolean, command: string, args: string[]) {
         let response: string | undefined;
+        if(!(args.length > 0)) return;
         const name = args[0];
 
         const regexp = /[a-z0-9-]+$/;

--- a/src/Info.ts
+++ b/src/Info.ts
@@ -33,7 +33,6 @@ export default class Info {
 
     public onAll(message: Discord.Message, isAdmin: boolean, command: string, args: string[]) {
         let response: string | undefined;
-        if (args.length !== 1) return;
         const name = args[0];
 
         const regexp = /[a-z0-9-]+$/;


### PR DESCRIPTION
At the moment, doing `.note {some text here}` or `!note note {some text here}` makes botty ignore that command, this is not optimal for when you want to @ someone in the same mesasge, or provide context