### PR TITLE
Add distinct message for 404 when checking library language

### DIFF
--- a/src/RiotAPILibraries.ts
+++ b/src/RiotAPILibraries.ts
@@ -131,15 +131,19 @@ export default class RiotAPILibraries {
 
     private async getListForLanguage(message: Discord.Message, language: string) {
         const response = await fetch(this.settings.riotApiLibraries.baseURL + language);
-        if (response.status !== 200) {
-
-            if (response.status === 404) {
+        switch (response.status) {
+            case 200: {
+                // continue
+                break;
+            }
+            case 404: {
                 message.channel.send(`I found no libraries for ${language}`);
                 return;
             }
-
-            message.channel.send(this.settings.riotApiLibraries.githubErrorLanguage + response.status);
-            return;
+            default: {
+                message.channel.send(this.settings.riotApiLibraries.githubErrorLanguage + response.status);
+                return;
+            }
         }
 
         const libraryList = await response.json();

--- a/src/RiotAPILibraries.ts
+++ b/src/RiotAPILibraries.ts
@@ -132,6 +132,12 @@ export default class RiotAPILibraries {
     private async getListForLanguage(message: Discord.Message, language: string) {
         const response = await fetch(this.settings.riotApiLibraries.baseURL + language);
         if (response.status !== 200) {
+
+            if (response.status === 404) {
+                message.channel.send(`I found no libraries for ${language}`);
+                return;
+            }
+
             message.channel.send(this.settings.riotApiLibraries.githubErrorLanguage + response.status);
             return;
         }


### PR DESCRIPTION
A 404 from github in this context means that there is no library for that language. 
We should distinguish "no language found" from a generic "http request failed" error