### PR TITLE
Improve API call URL error detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,15 @@
     "pretty-ms": "^3.0.0",
     "turndown": "^4.0.2",
     "turndown-plugin-gfm": "^1.0.2",
-    "uws": "9.14.0"
+    "uws": "9.14.0",
+    "xregexp": "^4.2.0"
   },
   "devDependencies": {
     "@types/cheerio": "^0.22.8",
     "@types/node": "^8.0.22",
     "@types/node-fetch": "^1.6.7",
     "@types/pretty-ms": "^3.0.0",
+    "@types/xregexp": "^3.0.29",
     "typescript": "^2.4.2",
     "tslint": "^5.10.0"
   }


### PR DESCRIPTION
I overhauled the API call identification and error detection extension. It would be greatly appreciated if somebody wants to do a code review, and also test any edge cases you can think of.

Enhancements:
- Works correctly when query parameters are specified
- Identifies missing required query parameters
- Identifies query parameters that are the incorrect type
- Identifies query parameters that do not exist for the used endpoint
- Identifies calls that use HTTP instead of HTTPS
- Can identify multiple API calls in one message
- Doesn't make API calls that are expected to fail
- Works with tournament-stub-v3