### PR TITLE
Add remaining settings to the config

### DIFF
--- a/private/shared_settings.json
+++ b/private/shared_settings.json
@@ -13,6 +13,14 @@
             "username": "Querijn",
             "password": ""
         },
-        "isProduction": false
+        "riotApi": {
+            "key": ""
+        },
+        "webServer": {
+            "relativeFolderLocation": "www/",
+            "relativeLiveLocation": "my.cool.url"
+        },
+        "isProduction": false,
+        "appName":"app"
     }
 }


### PR DESCRIPTION
Since the private file overwrites the public file, the missing params from the private file removes whatever you have in the public config.