### PR TITLE
Update community of changes on certain pages.

### DIFF
--- a/data/page_differ.json
+++ b/data/page_differ.json
@@ -1,0 +1,1 @@
+{"hashes":{"article202294884":-1090264497,"pagehttps://www.riotgames.com/en/legal":-1751093520}}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "bufferutil": "^3.0.0",
     "cheerio": "^1.0.0-rc.2",
+    "crc-32": "^1.2.0",
     "discord.js": "11.3.2",
     "feed-read": "^0.0.1",
     "moment": "^2.22.2",

--- a/settings/shared_settings.json
+++ b/settings/shared_settings.json
@@ -57,6 +57,24 @@
         "channel": "external-activity",
         "url": "http://discussion.developer.riotgames.com/"
     },
+    "pageDiffer": {
+        "checkInterval": 600000,
+        "channel": "external-activity",
+        "pages": [
+            {
+                "name": "Champion Update Schedule",
+                "ident": "202294884",
+                "type": "article"
+            },
+            {
+                "name": "Legal Jibber Jabber",
+                "ident": "https://www.riotgames.com/en/legal",
+                "type": "page"
+            }
+        ],
+        "articleHost": "https://support.riotgames.com/api/v2/help_center/en-us/articles/{id}.json",
+        "embedImageUrl": "https://irule.at/riot/api/morello.png"
+    },
     "info": {
         "allowedRoles": [
             "187653195038720000",

--- a/src/PageDiffer.ts
+++ b/src/PageDiffer.ts
@@ -1,0 +1,133 @@
+import { fileBackedObject } from "./FileBackedObject";
+import { SharedSettings, PageType, PageDifferPage } from "./SharedSettings";
+
+import Discord = require("discord.js");
+import crc32 = require("crc-32");
+import fs = require("fs");
+import fetch from "node-fetch";
+import Info from "./Info";
+
+interface PageDifferData {
+    hashes: { [page: string]: number };
+}
+
+/**
+ * Checks differences in pages
+ *
+ * @export
+ * @class PageDiffer
+ */
+export default class PageDiffer {
+    private bot: Discord.Client;
+    private channel: Discord.TextChannel;
+    private sharedSettings: SharedSettings;
+    private data: PageDifferData;
+    private timeOut: number | null;
+
+    constructor(bot: Discord.Client, sharedSettings: SharedSettings, pageDiffFile: string) {
+        console.log("Requested PageDiffer extension..");
+        this.bot = bot;
+
+        this.sharedSettings = sharedSettings;
+        this.data = fileBackedObject(pageDiffFile);
+
+        this.bot.on("ready", this.onBot.bind(this));
+    }
+
+    public async onBot() {
+        const guild = this.bot.guilds.get(this.sharedSettings.server);
+        if (!guild) {
+            console.error(`PageDiffer: Unable to find server with ID: ${this.sharedSettings.server}`);
+            return;
+        }
+
+        const channel = guild.channels.find("name", this.sharedSettings.pageDiffer.channel);
+        if (!channel || !(channel instanceof Discord.TextChannel)) {
+            console.error(`PageDiffer: Unable to find channel: ${this.sharedSettings.pageDiffer.channel}`);
+            return;
+        }
+
+        this.channel = channel as Discord.TextChannel;
+        console.log("PageDiffer extension loaded.");
+
+        this.checkPages();
+    }
+
+    private getFetchUrl(page: PageDifferPage) {
+
+        switch (page.type) {
+            case PageType.Article:
+                return this.sharedSettings.pageDiffer.articleHost.replace(/{id}/g, page.ident); // In the case of an article, page.ident is an ID number
+
+            case PageType.Page:
+                return page.ident; // In the case of a page, page.ident is the URL.
+
+            default:
+                throw new Error("getFetchUrl was given an undefined page type");
+        }
+    }
+
+    private async checkPages() {
+
+        for (const page of this.sharedSettings.pageDiffer.pages) {
+
+            const fetchUrl = this.getFetchUrl(page);
+
+            const resp = await fetch(fetchUrl);
+            if (resp.status !== 200) {
+                console.warn(`PageDiffer got an unusual HTTP status code checking for ${page.type} "${page.name}". "${fetchUrl}" returns ${resp.status}.`);
+                continue;
+            }
+
+            let body = "";
+            let pageLocation = page.ident;
+            switch (page.type) {
+                case PageType.Article: {
+                    const article = (await resp.json()).article;
+                    pageLocation = article.html_url;
+                    body = article.body;
+                    break;
+                }
+
+                case PageType.Page: {
+                    body = await resp.text();
+                    break;
+                }
+            }
+
+            const hash = crc32.str(body);
+            // if (this.data.hashes[page.type + page.ident] === hash) continue;
+
+            // Make sure the folders are there
+            if (!fs.existsSync("www")) fs.mkdirSync("www");
+            if (!fs.existsSync("www/pages")) fs.mkdirSync("www/pages");
+
+            const cleanName = page.name.toLowerCase().replace(/[\W_]+/g, "-");
+            const folderName = "pages/" + cleanName + "/";
+            const hasDiff = fs.existsSync("www/" + folderName);
+            if (!hasDiff) fs.mkdirSync("www/" + folderName);
+
+            // Save the file and the info about the file
+            const curTime = Date.now();
+            fs.writeFileSync("www/" + folderName + curTime + "_info.json", JSON.stringify(page));
+            fs.writeFileSync("www/" + folderName + curTime + ".html", body);
+            fs.writeFileSync("www/" + folderName + "index.json", JSON.stringify(fs.readdirSync("www/" + folderName).filter(f => f.endsWith(".html")).map(f => f.replace(/.html/g, ""))));
+            this.data.hashes[page.type + page.ident] = hash;
+
+            // Get to the posting part, if we have a difference
+            if (!hasDiff) continue;
+
+            const embed = new Discord.RichEmbed()
+                .setColor(0xffca95)
+                .setTitle(`The ${page.type} "${page.name}" has changed`)
+                .setDescription(`Something has changed on "${page.name}".\n\nYou can see the current version here: ${pageLocation}\n\nYou can check out the difference here: ${this.sharedSettings.botty.webServer.relativeLiveLocation + folderName}`)
+                .setURL(this.sharedSettings.botty.webServer.relativeLiveLocation + folderName)
+                .setThumbnail(this.sharedSettings.pageDiffer.embedImageUrl);
+
+            this.channel.send({ embed });
+        }
+
+        if (this.timeOut !== null) clearTimeout(this.timeOut);
+        this.timeOut = setTimeout(this.checkPages.bind(this), this.sharedSettings.pageDiffer.checkInterval);
+    }
+}

--- a/src/SharedSettings.ts
+++ b/src/SharedSettings.ts
@@ -24,6 +24,17 @@ export interface PersonalSettings {
     appName: string;
 }
 
+export enum PageType {
+    Page = "page",
+    Article = "article",
+}
+
+export interface PageDifferPage {
+    name: string;
+    ident: string;
+    type: PageType;
+}
+
 export interface SharedSettings {
     server: string;
 
@@ -58,6 +69,14 @@ export interface SharedSettings {
         checkInterval: number,
         channel: string,
         url: string,
+    };
+
+    pageDiffer: {
+        checkInterval: number,
+        channel: string,
+        pages: PageDifferPage[],
+        articleHost: string,
+        embedImageUrl: string,
     };
 
     autoReact: {

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import VersionChecker from "./VersionChecker";
 import ESportsAPI from "./ESports";
 import Pickem from "./Pickem";
 import Endpoint from "./Endpoint";
+import PageDiffer from "./PageDiffer";
 
 import { APISchema } from "./ApiSchema";
 import { CommandList } from "./CommandController";
@@ -47,6 +48,7 @@ const libraries = new RiotAPILibraries(sharedSettings);
 const esports = new ESportsAPI(bot.client, sharedSettings);
 const pickem = new Pickem(bot.client, sharedSettings);
 const endpoint = new Endpoint(sharedSettings, "data/endpoints.json");
+const pageDiffer = new PageDiffer(bot.client, sharedSettings, "data/page_differ.json");
 
 // Commands controller commands
 controller.registerCommand(commandList.controller.toggle, controller.onToggle.bind(controller));


### PR DESCRIPTION
With this change, you could visit #external-activity, and you would see messages such as this one:
![image](https://user-images.githubusercontent.com/3397066/47604776-570a1800-d9fe-11e8-87f3-36da7386d6fe.png)

This is interesting to know for those that want to keep up to date on changes to API documents of which users would not always be updated for, eg. the Legal Jibber Jabber.

The page-diff website is already online, and an example can be found here: https://irule.at/riot/api/pages/legal-jibber-jabber/

The text in this example is fabricated.
