### PR TITLE
stabilized !lookup sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "compile": "tsc -p .",
-    "start": "tsc -p . && node ./dist/app.js"
+    "start": "tsc -p . && node ./dist/app.js",
+    "test": "mocha -r ts-node/register test/**/*.spec.ts"
   },
   "author": "Querijn Heijmans <querijn@irule.at>",
   "license": "MIT",
@@ -30,12 +31,19 @@
     "xregexp": "^4.2.0"
   },
   "devDependencies": {
+    "@types/chai": "^4.2.3",
     "@types/cheerio": "^0.22.8",
+    "@types/mocha": "^5.2.7",
     "@types/node": "^8.0.22",
     "@types/node-fetch": "^1.6.7",
     "@types/pretty-ms": "^3.0.0",
     "@types/xregexp": "^3.0.29",
-    "typescript": "^2.4.2",
-    "tslint": "^5.10.0"
+    "chai": "^4.2.0",
+    "mocha": "^6.2.1",
+    "ts-mockito": "^2.5.0",
+    "ts-node": "^8.4.1",
+    "tslint": "^5.10.0",
+    "typemoq": "^2.1.0",
+    "typescript": "^2.4.2"
   }
 }

--- a/src/GameData.ts
+++ b/src/GameData.ts
@@ -238,7 +238,7 @@ export default class GameData {
         for (const [key, value] of Object.entries(rawData)) {
             const keyString = key.toString().charAt(0).toUpperCase() + key.toString().slice(1);
             const valueString = striptags(value.toString());
-            if (valueString !== "") { 
+            if (valueString !== "") {
                 if (Array.isArray(value)) {
                     if (value.length > 4) {
                         embed.addField(keyString, `${value.slice(0, 4).join(", ")} + ${value.length - 4} more…`);
@@ -258,48 +258,54 @@ export default class GameData {
         if (a.score === 0) return -1;
         if (b.score === 0) return 1;
 
-        const nameA = a.item.name.toLowerCase();
-        const nameB = b.item.name.toLowerCase();
+        const ishCompare = (x: string, y: string) => {
+            const lowerX = x.toLowerCase();
+            const lowerY = y.toLowerCase();
 
-        if (nameA === search) return -1;
-        if (nameB === search) return 1;
+            if (lowerX === lowerY) return 0;
+            if (lowerX === search) return -1;
+            if (lowerY === search) return 1;
 
-        if (nameA.startsWith(search) && !nameB.startsWith(search)) return -1;
-        if (nameB.startsWith(search) && !nameA.startsWith(search)) return 1;
+            const xStarts = lowerX.startsWith(search);
+            const yStarts = lowerY.startsWith(search);
 
-        if (nameA.includes(search) && !nameB.includes(search)) return -1;
-        if (nameB.includes(search) && !nameA.includes(search)) return 1;
+            if (xStarts && yStarts) return 0;
+            if (xStarts) return -1;
+            if (yStarts) return 1;
+
+            const xIncludes = lowerX.includes(search);
+            const yIncludes = lowerY.includes(search);
+
+            if (xIncludes && yIncludes) return 0;
+            if (xIncludes) return -1;
+            if (yIncludes) return 1;
+
+            return 0;
+        };
+
+        const nameCmp = ishCompare(a.item.name, b.item.name);
+        if (nameCmp !== 0) return nameCmp;
 
         if (a.item.key && b.item.key) {
-            const keyA = a.item.key;
-            const keyB = b.item.key;
-
-            if (keyA === search) return -1;
-            if (keyB === search) return 1;
-
-            if (keyA.startsWith(search) && !keyB.startsWith(search)) return -1;
-            if (keyB.startsWith(search) && !keyA.startsWith(search)) return 1;
-
-            if (keyA.includes(search) && !keyB.includes(search)) return -1;
-            if (keyB.includes(search) && !keyA.includes(search)) return 1;
+            const keyCmp = ishCompare(a.item.key, b.item.key);
+            if (keyCmp !== 0) return keyCmp;
         }
 
-        const idA = a.item.id.toString();
-        const idB = a.item.id.toString();
-
-        if (idA === search) return -1;
-        if (idB === search) return 1;
-
-        if (idA.startsWith(search) && !idB.startsWith(search)) return -1;
-        if (idB.startsWith(search) && !idA.startsWith(search)) return 1;
-
-        if (idA.includes(search) && !idB.includes(search)) return -1;
-        if (idB.includes(search) && !idA.includes(search)) return 1;
+        const idCmp = ishCompare(a.item.id.toString(), b.item.id.toString());
+        if (idCmp !== 0) return idCmp;
 
         if (a.score < b.score) return -1;
         if (b.score < a.score) return 1;
 
-        return 0;
+        const aCmpBName = a.item.name.localeCompare(b.item.name);
+        if (aCmpBName !== 0) return aCmpBName;
+
+        if (a.item.key && b.item.key) {
+            const aCmpBKey = a.item.key.localeCompare(b.item.key);
+            if (aCmpBKey !== 0) return aCmpBKey;
+        }
+
+        return a.item.id - b.item.id;
     }
 
     public findItem(search: string): string | ItemData {

--- a/test/GameData.spec.ts
+++ b/test/GameData.spec.ts
@@ -1,0 +1,153 @@
+
+import Discord = require("discord.js");
+
+import { should } from "chai";
+should();
+import * as TypeMoq from "typemoq";
+
+import GameData from "../src/GameData";
+import { SharedSettings } from "../src/SharedSettings";
+
+describe("GameData", () => {
+    describe("#sortSearch(...)", () => {
+        const mockClient = TypeMoq.Mock.ofType(Discord.Client);
+        const mockSettings = TypeMoq.Mock.ofType<SharedSettings>();
+
+        const data = new GameData(mockClient.object, mockSettings.object);
+
+        const sortSearchTestHelper: typeof data.sortSearch = (
+            search, smaller, larger,
+        ) => {
+            const res = data.sortSearch(search, smaller, larger);
+            res.should.be.lessThan(0);
+
+            const res2 = data.sortSearch(search, larger, smaller);
+            res2.should.be.greaterThan(0);
+
+            return 0;
+        };
+
+        it("should return 0 for equal the same object", () => {
+            const res = data.sortSearch(
+                "fgsgfds",
+                {
+                    item: {id: 1, name: "1"},
+                    score: 1,
+                },
+                {
+                    item: {id: 1, name: "1"},
+                    score: 1,
+                },
+            );
+
+            res.should.equal(0);
+        });
+
+        it("should return an object with a score of 0", () => {
+            const smaller = {item: {id: 1, name: "1"}, score: 0};
+            const larger = {item: {id: 2, name: "2"}, score: 1};
+
+            sortSearchTestHelper("fff", smaller, larger);
+        });
+
+        it("should check name for exact match after score", () => {
+            const equal = {item: {id: 1, name: "AAA"}, score: 1};
+            const notEqual = {item: {id: 2, name: "abcaaa"}, score: 1};
+
+            sortSearchTestHelper("aaa", equal, notEqual);
+        });
+
+        it("should check if name starts with search after score", () => {
+            const equal = {item: {id: 1, name: "ChoGath"}, score: 3};
+            const notEqual = {item: {id: 2, name: "dfdfcho"}, score: 3};
+
+            sortSearchTestHelper("cho", equal, notEqual);
+        });
+
+        it("should check if name contains the search string after score", () => {
+            const equal = {item: {id: 1, name: "ChoGath"}, score: 3};
+            const notEqual = {item: {id: 2, name: "ChGth"}, score: 3};
+
+            sortSearchTestHelper("gath", equal, notEqual);
+        });
+
+        it("should check key for exact match after name", () => {
+            const equal = {item: {id: 1, key: "cho", name: "ff"}, score: 3};
+            const notEqual = {item: {id: 2, key: "gath", name: "fdfd"}, score: 3};
+
+            sortSearchTestHelper("cho", equal, notEqual);
+        });
+
+        it("should check if key starts with the search after name", () => {
+            const equal = {item: {id: 1, key: "chogath", name: "ff"}, score: 3};
+            const notEqual = {item: {id: 2, key: "gathcho", name: "fdfd"}, score: 3};
+
+            sortSearchTestHelper("cho", equal, notEqual);
+        });
+
+        it("should check if key contains the search after name", () => {
+            const equal = {item: {id: 1, key: "chogath", name: "ff"}, score: 3};
+            const notEqual = {item: {id: 2, key: "chgth", name: "fdfd"}, score: 3};
+
+            sortSearchTestHelper("gath", equal, notEqual);
+        });
+
+        it("should check id for exact match after name and key", () => {
+            const equal = {item: {id: 1, key: "abc", name: "ff"}, score: 3};
+            const notEqual = {item: {id: 2, key: "def", name: "fdfd"}, score: 3};
+
+            sortSearchTestHelper("1", equal, notEqual);
+        });
+
+        // todo: this seems... dumb AF. Why would you want a partial search by ID...?
+        it("should check if id starts with search after name and key", () => {
+            const equal = {item: {id: 12, name: "ff"}, score: 3};
+            const notEqual = {item: {id: 22, name: "fdfd"}, score: 3};
+
+            sortSearchTestHelper("1", equal, notEqual);
+        });
+
+        // todo: this seems... dumb AF. Why would you want a partial search by ID...?
+        it("should check if id contains search after name and key", () => {
+            const equal = {item: {id: 21, name: "ff"}, score: 3};
+            const notEqual = {item: {id: 22, name: "fdfd"}, score: 3};
+
+            sortSearchTestHelper("1", equal, notEqual);
+        });
+
+        it("should check score after checking all other possible matches", () => {
+            const smaller = {item: {id: 123, name: "ff"}, score: 3};
+            const larger = {item: {id: 321, name: "fdfd"}, score: 6};
+
+            sortSearchTestHelper("hello", smaller, larger);
+        });
+
+        it("should alphabetize by name when scores equal", () => {
+            const smaller = {item: {id: 1, name: "aaabc"}, score: 1};
+            const larger = {item: {id: 1, name: "aaaDEF"}, score: 1};
+
+            sortSearchTestHelper("hello", smaller, larger);
+        });
+
+        it("should alphabetize by key when scores and name equal", () => {
+            const smaller = {item: {id: 1, key: "aaabc", name: "aa"}, score: 1};
+            const larger = {item: {id: 1, key: "aaaDEF", name: "aa"}, score: 1};
+
+            sortSearchTestHelper("hello", smaller, larger);
+        });
+
+        it("should order by id when scores and name equal and no key provided", () => {
+            const smaller = {item: {id: 1, name: "aa"}, score: 1};
+            const larger = {item: {id: 2, name: "aa"}, score: 1};
+
+            sortSearchTestHelper("hello", smaller, larger);
+        });
+
+        it("should order by id when scores, name, and key equal", () => {
+            const smaller = {item: {id: 1, key: "bb", name: "aa"}, score: 1};
+            const larger = {item: {id: 2, key: "bb", name: "aa"}, score: 1};
+
+            sortSearchTestHelper("hello", smaller, larger);
+        });
+    });
+});


### PR DESCRIPTION
Sorting of items, champs, and perks with `!lookup` is not stable. Searching the same thing multiple times results in different results. This fixes that issue. Precedence is now:

1. Exact name match
2. Fuzzy name match
3. Exact key match
4. Fuzzy key match
5. Exact ID match
6. Fuzzy ID match (idk why this is a thing, but @stelar7 added it, so I kept it)
7. Levenshtein Distance diff
8. Alphabetized name
9. Alphabetized key
10. Ordered IDs

Also fixes a bug where the ID of the second item provided to sort was never used.

And I added unit tests. Run them with `npm test`