### PR TITLE
added travis CI to botty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - node
+  - lts/*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BottyMcBotface
 
+[![Build Status](https://travis-ci.org/pseudonym117/BottyMcBotface.svg?branch=master)](https://travis-ci.org/pseudonym117/BottyMcBotface)
+
 The Riot Games API Discord Bot. This is the bot that helps out with your questions regarding the Riot Games API. 
 
 ## Available commands

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/fs-extra": "^5.0.4",
-    "bufferutil": "^3.0.0",
+    "bufferutil": "^4.0.0",
     "cheerio": "^1.0.0-rc.2",
     "crc-32": "^1.2.0",
     "discord.js": "11.3.2",
@@ -31,6 +31,7 @@
     "xregexp": "^4.2.0"
   },
   "devDependencies": {
+    "@types/chai": "^4.2.4",
     "@types/cheerio": "^0.22.8",
     "@types/mocha": "^5.2.7",
     "@types/node": "^8.0.22",


### PR DESCRIPTION
Turns out the issue was a dependency of `bufferutil`, not `@types/chai`. Or so it seems. Upgrading `bufferutil` results in everything running through CI.

You're gonna need to link [TravisCI](https://travis-ci.org/) to your github and authorize it to access this repo. Then, I would recommend the settings being ON:

- Build Pushed branches
- Build pushed pull requests
- Auto cancel branch builds
- Auto cancel pull request builds

Cron Job:
 - `master` branch, `daily`, `always run`

Also should change the image in `README.md` to point to your build status image/URL instead of mine.