### PR TITLE
Update VersionChecker to match Riot Games new Patch Notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fs-extra": "^7.0.1",
     "html2plaintext": "^2.1.0",
     "moment": "^2.22.2",
-    "node-fetch": "^1.7.2",
+    "node-fetch": "^2.6.0",
     "pretty-ms": "^3.0.0",
     "striptags": "^3.1.1",
     "turndown": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/cheerio": "^0.22.8",
     "@types/mocha": "^5.2.7",
     "@types/node": "^8.0.22",
-    "@types/node-fetch": "^1.6.7",
+    "@types/node-fetch": "^2.5.4",
     "@types/pretty-ms": "^3.0.0",
     "@types/xregexp": "^3.0.29",
     "chai": "^4.2.0",

--- a/src/VersionChecker.ts
+++ b/src/VersionChecker.ts
@@ -104,36 +104,36 @@ export default class VersionChecker {
 
             do {
                 nextMinor++;
-                patchNotes = `https://na.leagueoflegends.com/en/news/game-updates/patch/patch-${nextMajor.toString()}${nextMinor.toString()}-notes`;
+                patchNotes = `https://na.leagueoflegends.com/en/news/game-updates/patch-${nextMajor.toString()}-${nextMinor.toString()}-notes/`;
                 tries++;
 
                 let response = await fetch(patchNotes, {
                     method: "GET",
                 });
 
-                if (response.status === 200) {
+                if (response.status === 200 && response.redirected === false) {
                     lastNewValidMajor = nextMajor;
                     lastNewValidMinor = nextMinor;
                     validPatchNotes = patchNotes;
                     newPatch = true;
-                } else if (response.status === 404) {
+                } else if (response.status === 200 && response.redirected === true) {
                     // check for change in season
                     nextMajor++;
                     nextMinor = 1;
 
-                    patchNotes = `https://na.leagueoflegends.com/en/news/game-updates/patch/patch-${nextMajor.toString()}${nextMinor.toString()}-notes`;
+                    patchNotes = `https://na.leagueoflegends.com/en/news/game-updates/patch-${nextMajor.toString()}-${nextMinor.toString()}-notes/`;
                     tries++;
 
                     response = await fetch(patchNotes, {
                         method: "GET",
                     });
 
-                    if (response.status === 200) {
+                    if (response.status === 200 && response.redirected === false) {
                         lastNewValidMajor = nextMajor;
                         lastNewValidMinor = nextMinor;
                         validPatchNotes = patchNotes;
                         newPatch = true;
-                    } else if (response.status === 404) break;
+                    } else if (response.status === 200 && response.redirected === true) break;
                 }
             }
             while (tries < 100);


### PR DESCRIPTION
Riot has changed their URL schema, as well as redirecting all URLs to their main page.

PR includes upgrading node-fetch to new version to include the response.redirected check, then I have added it to the if statements on VersionChecker.ts.

It potentially could be better to rewrite this whole if else chain as it doesn't make as much sense now.