### PR TITLE
Modified lolesports link | old one did not work properly

### DIFF
--- a/src/ESports.ts
+++ b/src/ESports.ts
@@ -269,6 +269,6 @@ export default class ESportsAPI {
 
     private getUrlByLeague(leagueName: ESportsLeagueSchedule) {
 
-        return "https://watch.lolesports.com/schedule?leagues=" + leagueName.url;
+        return "https://lolesports.com/schedule?leagues=" + leagueName.url;
     }
 }


### PR DESCRIPTION
What did I change?
The link (example) https://watch.lolesports.com/schedule?leagues=primeleague does not redirect to the "prime league", it redirects me to the "lec", most likely because of my geolocation. 
It seems like watch.lolesports.com/schedule?leagues=... redirects to lolesports.com/schedule , without keeping the query parameters. 
That's why I changed the URL, it is a minor change, sorry for stealing your time lol