### PR TITLE
Fix check for allowed URLs

### DIFF
--- a/src/SpamKiller.ts
+++ b/src/SpamKiller.ts
@@ -134,9 +134,9 @@ export default class SpamKiller {
 
         const d = url.parse(urlString);
         const hostname = d.hostname || "";
-        if (this.sharedSettings.spam.allowedUrls.findIndex(u => hostname.endsWith(u)) !== -1)
+        if (this.sharedSettings.spam.allowedUrls.findIndex(u => hostname.endsWith(u) &&
+        (hostname.replace(u, "").endsWith(".") || hostname.replace(u, "").length === 0)) !== -1) // Only allow matching base domain (zero length after replace) and subdomains (ends with ".")
             return;
-
         this.addViolatingMessage(message, `Hey, ${message.author}, we require users to verify that they are human before they are allowed to post a link. If you are a human, react with :+1: to this message to gain link privileges. If you are a bot, please go spam somewhere else. 👍`);
     }
 

--- a/src/SpamKiller.ts
+++ b/src/SpamKiller.ts
@@ -134,7 +134,7 @@ export default class SpamKiller {
 
         const d = url.parse(urlString);
         const hostname = d.hostname || "";
-        if (this.sharedSettings.spam.allowedUrls.findIndex(u => u.endsWith(hostname)) !== -1)
+        if (this.sharedSettings.spam.allowedUrls.findIndex(u => hostname.endsWith(u)) !== -1)
             return;
 
         this.addViolatingMessage(message, `Hey, ${message.author}, we require users to verify that they are human before they are allowed to post a link. If you are a human, react with :+1: to this message to gain link privileges. If you are a bot, please go spam somewhere else. 👍`);


### PR DESCRIPTION
Previously it only matched if the URL was riotgames.com or leagueoflegends.com, but did not allow subdomains.