### PR TITLE
Add kick and ban commands to Botty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ dist/
 # Private bot files that shouldnt be shared
 private/
 www/
+
+# Mac
+.DS_Store

--- a/settings/command_list.json
+++ b/settings/command_list.json
@@ -14,10 +14,10 @@
             "aliases": [
                 "lookup",
                 "search",
-                "item", 
-                "perk", 
-                "rune", 
-                "champion", 
+                "item",
+                "perk",
+                "rune",
+                "champion",
                 "champ",
                 "summonerspell",
                 "summ",
@@ -41,6 +41,20 @@
                 "mute"
             ],
             "description": "Mutes a user"
+        },
+        "ban": {
+            "admin": true,
+            "aliases": [
+                "ban"
+            ],
+            "description": "Ban one or several users with a specific note or message. "
+        },
+        "kick": {
+            "admin": true,
+            "aliases": [
+                "kick"
+            ],
+            "description": "Kick one or several users with a specific note or message. "
         },
         "unmute": {
             "admin": true,

--- a/settings/shared_settings.json
+++ b/settings/shared_settings.json
@@ -56,7 +56,12 @@
     "admin": {
         "muteRoleId": "428943553167884307",
         "muteRoleName": "muted",
-        "muteTimeout": 86400000
+        "muteTimeout": 86400000,
+        "keepAdminCommandsChannels": [
+            "865107613992616007",
+            "866816996900864041",
+            "429367396420157460"
+        ]
     },
     "esports": {
         "printChannel": "lol-esports",

--- a/src/Admin.ts
+++ b/src/Admin.ts
@@ -231,20 +231,19 @@ export default class Admin {
                 });
             }
 
-            let catched = false;
-            member.ban({ reason: (reason.length > 0 ? this.shorten(reason) : "No reason") + " -" + message.author.username }).catch(e => {
-                catched = true;
+            try {
+                await member.ban({ reason: (reason.length > 0 ? this.shorten(reason) : "No reason") + " -" + message.author.username });
+            } catch (e) {
                 this.replySecretMessage(message, `Failed to ban ${member}: ${e}`);
-            })
-
-            if (!catched) {
-                if (reason.length > 0) {
-                    this.replySecretMessage(message, `${member} was banned by ${message.author.username} due to "${reason}". ${note}`);
-                } else {
-                    this.replySecretMessage(message, `${member} was banned by ${message.author.username}. ${note}`);
-                }
-                removed++;
+                continue;
             }
+
+            if (reason.length > 0) {
+                this.replySecretMessage(message, `${member} was banned by ${message.author.username} due to "${reason}". ${note}`);
+            } else {
+                this.replySecretMessage(message, `${member} was banned by ${message.author.username}. ${note}`);
+            }
+            removed++;
         }
 
         if (members.length > 1) {
@@ -279,20 +278,20 @@ export default class Admin {
                 });
             }
 
-            let catched = false;
-            member.kick((reason.length > 0 ? this.shorten(reason) : "No reason") + " -" + message.author.username).catch(e => {
-                catched = true;
-                this.replySecretMessage(message, `Failed to kick ${member}: ${e}`);
-            })
-
-            if (!catched) {
-                if (reason.length > 0) {
-                    this.replySecretMessage(message, `${member} was kicked by ${message.author.username} due to "${reason}". ${note}`);
-                } else {
-                    this.replySecretMessage(message, `${member} was kicked by ${message.author.username}. ${note}`);
-                }
-                removed++;
+            try {
+                await member.kick((reason.length > 0 ? this.shorten(reason) : "No reason") + " -" + message.author.username);
             }
+            catch (e) {
+                this.replySecretMessage(message, `Failed to kick ${member}: ${e}`);
+                continue;
+            }
+
+            if (reason.length > 0) {
+                this.replySecretMessage(message, `${member} was kicked by ${message.author.username} due to "${reason}". ${note}`);
+            } else {
+                this.replySecretMessage(message, `${member} was kicked by ${message.author.username}. ${note}`);
+            }
+            removed++;
         }
 
         if (members.length > 1) {

--- a/src/Admin.ts
+++ b/src/Admin.ts
@@ -123,6 +123,18 @@ export default class Admin {
         });
     }
 
+    private async deleteNonAdminChannelMessage(message: Discord.Message) {
+        if (!this.sharedSettings.admin.keepAdminCommandsChannels.includes(message.channel.id)) {
+            if (message.deletable) {
+                try {
+                    await message.delete();
+                } catch (e) {
+                    console.log(`Failed to delete message (https://discordapp.com/channels/${message.guild?.id}/${message.channel.id}/${message.id}): ${e}`);
+                }
+            }
+        }
+    }
+
 
     public async handleMultiUserArguments(message: Discord.Message, args: string[]) {
 
@@ -250,6 +262,8 @@ export default class Admin {
             this.replySecretMessage(message, `${message.author.username} has banned ${removed} users. `);
         }
 
+        await this.deleteNonAdminChannelMessage(message);
+
     }
 
     public async onKick(message: Discord.Message, isAdmin: boolean, command: string, args: string[], separators: string[]) {
@@ -297,6 +311,8 @@ export default class Admin {
         if (members.length > 1) {
             this.replySecretMessage(message, `${message.author.username} has kicked ${removed} users. `);
         }
+
+        await this.deleteNonAdminChannelMessage(message);
     }
 
     public async onMute(message: Discord.Message, isAdmin: boolean, command: string, args: string[], separators: string[]) {

--- a/src/Admin.ts
+++ b/src/Admin.ts
@@ -198,9 +198,14 @@ export default class Admin {
             .setDescription(`You were ${action} from the ${serverName}. \n\n**Reason**\n${reason}`)
     }
 
+    private shorten(string: string) {
+        if (string.length > 400) {
+            return string.slice(0, 400) + "..."
+        }
+        return string;
+    }
 
     public async onBan(message: Discord.Message, isAdmin: boolean, command: string, args: string[], separators: string[]) {
-
         if (!isAdmin || args.length === 0) {
             return;
         }
@@ -227,7 +232,7 @@ export default class Admin {
             }
 
             let catched = false;
-            member.ban({ reason: (reason.length > 0 ? reason : "No reason") + " -" + message.author.username }).catch(e => {
+            member.ban({ reason: (reason.length > 0 ? this.shorten(reason) : "No reason") + " -" + message.author.username }).catch(e => {
                 catched = true;
                 this.replySecretMessage(message, `Failed to ban ${member}: ${e}`);
             })
@@ -275,7 +280,7 @@ export default class Admin {
             }
 
             let catched = false;
-            member.kick((reason.length > 0 ? reason : "No reason") + " -" + message.author.username).catch(e => {
+            member.kick((reason.length > 0 ? this.shorten(reason) : "No reason") + " -" + message.author.username).catch(e => {
                 catched = true;
                 this.replySecretMessage(message, `Failed to kick ${member}: ${e}`);
             })

--- a/src/CommandController.ts
+++ b/src/CommandController.ts
@@ -40,6 +40,8 @@ export interface CommandList {
         unmute: Command;
         mute: Command;
         ticket: Command;
+        ban: Command;
+        kick: Command;
     };
     esports: {
         date: Command;

--- a/src/Info.ts
+++ b/src/Info.ts
@@ -386,7 +386,7 @@ export default class Info {
             await reply.react(category.icon).catch((reason) => console.log(`Cannot react with category '${category}', reason being: ${reason}`));
     }
 
-    private fetchInfo(command: string): InfoData | null {
+    public fetchInfo(command: string, trueMatch: boolean = false): InfoData | null {
 
         if (command.length === 0) return null;
         if (command.length > 300) return { message: `Stop it. Get some help.`, counter: 0, command, categoryId: "" };
@@ -408,6 +408,7 @@ export default class Info {
 
             // if there is more than one note, print the list
             if (data.length > 1) {
+                if (trueMatch) { return null; }
                 let message = "Did you mean: ";
                 message += data.map(s => "`" + s.command + "`").join(", ") + "?";
                 return { message, counter: 0, command, categoryId: "" };
@@ -419,12 +420,15 @@ export default class Info {
 
                 // Return a copy
                 info = Object.assign({}, orig);
-                info.message = `Assuming you meant \`${info.command}\`: ${info.message}`;
+                if (!trueMatch) {
+                    info.message = `Assuming you meant \`${info.command}\`: ${info.message}`;
+                }
 
                 orig.counter = orig.counter != null ? orig.counter + 1 : 0;
             }
 
             if (!info) {
+                if (trueMatch) { return null; }
                 return { message: `No note with the name ${command} was found.`, counter: 0, command, categoryId: "" };
             }
         }

--- a/src/SharedSettings.ts
+++ b/src/SharedSettings.ts
@@ -39,7 +39,7 @@ export interface PageDifferPage {
 
 interface IntroLine {
     id: string;
-    lineTranslation: {[lang: string]: string };
+    lineTranslation: { [lang: string]: string };
     type: "rule" | "intro";
 }
 
@@ -71,6 +71,7 @@ export interface SharedSettings {
         muteRoleId: string;
         muteRoleName: string;
         muteTimeout: number;
+        keepAdminCommandsChannels: string[];
     };
 
     esports: {

--- a/src/app.ts
+++ b/src/app.ts
@@ -60,7 +60,7 @@ controller.registerCommand(commandList.admin.unmute, admin.onUnmute.bind(admin))
 controller.registerCommand(commandList.admin.mute, admin.onMute.bind(admin));
 controller.registerCommand(commandList.admin.ticket, admin.onTicket.bind(admin));
 controller.registerCommand(commandList.admin.kick, admin.onKick.bind(admin));
-controller.registerCommand(commandList.admin.ban, admin.onKick.bind(admin));
+controller.registerCommand(commandList.admin.ban, admin.onBan.bind(admin));
 
 // Esport commands
 controller.registerCommand(commandList.esports.date, esports.onCheckNext.bind(esports));

--- a/src/app.ts
+++ b/src/app.ts
@@ -35,7 +35,7 @@ const techblog = new Techblog(bot.client, sharedSettings, "data/techblog_data.js
 const apiUrlInterpreter = new ApiUrlInterpreter(bot.client, sharedSettings, apiSchema);
 const versionChecker = new VersionChecker(bot.client, sharedSettings, "data/version_data.json");
 const notes = new Info(bot, sharedSettings, "data/info_data.json", versionChecker);
-const admin = new Admin(bot.client, sharedSettings, "data/admin_data.json");
+const admin = new Admin(bot.client, sharedSettings, "data/admin_data.json", notes);
 const react = new AutoReact(bot.client, sharedSettings, "data/thinking_data.json", "data/ignored_react_data.json");
 const status = new ApiStatus(sharedSettings);
 const libraries = new RiotAPILibraries(sharedSettings);
@@ -59,6 +59,8 @@ controller.registerCommand(commandList.gamedata.lookup, gameData.onLookup.bind(g
 controller.registerCommand(commandList.admin.unmute, admin.onUnmute.bind(admin));
 controller.registerCommand(commandList.admin.mute, admin.onMute.bind(admin));
 controller.registerCommand(commandList.admin.ticket, admin.onTicket.bind(admin));
+controller.registerCommand(commandList.admin.kick, admin.onKick.bind(admin));
+controller.registerCommand(commandList.admin.ban, admin.onKick.bind(admin));
 
 // Esport commands
 controller.registerCommand(commandList.esports.date, esports.onCheckNext.bind(esports));


### PR DESCRIPTION
Based on [this request](https://discord.com/channels/187652476080488449/187652476080488449/1094657023615959062), Botty can now !kick or !ban members. 
The kick and ban commands supports multiple users, tagged or as a raw snowflake. Additionally, a .note can be added as a quick ban message. 

## Example: 
- `!ban @user 1234snowflake56789 .we-mad` 
- `!ban @user` => no message is ok
- `!kick 1234snowflake56789 .shipment you got kicked with a shipment` => text after the note is also totally fine
- `!kick @user no note is also good to go`
The user will be notified if a ban message was set

## Security:
- Requires an admin role
- Can't kick/ban users with an admin role

## Features that could be added but I wasn't sure so lets discuss:
- Delete the messages of a banned user (within last x days / weeks etc)
- Delete the `!kick` || `!ban` command in a non-guru-channel