### PR TITLE
Adding a command that shows how many peoply are banned on the server

### DIFF
--- a/settings/command_list.json
+++ b/settings/command_list.json
@@ -237,5 +237,12 @@
             ],
             "description": "Shows a list of all Riot API endpoints."
         }
+    },
+    "banCount": {
+        "aliases": [
+            "ban_count",
+            "bancount"
+        ],
+        "description": "Prints the number of bans on the server"
     }
 }

--- a/src/BanCount.ts
+++ b/src/BanCount.ts
@@ -1,0 +1,31 @@
+import Discord = require("discord.js");
+import { setTimeout } from "timers";
+
+
+/**
+ *  Sends a embed with the number of bans on the server
+ */
+export default class BanCount {
+    private async banCount(message: Discord.Message) {
+        
+        const guild = message.guild;
+        if (!guild) {
+            return;
+        }
+
+        const bans = await guild.fetchBans();
+        const banCount = bans.size;
+
+        const embed = new Discord.MessageEmbed()
+            .setTitle("Ban Count")
+            .setDescription(`There are **${banCount}** bans on this server.`)
+            .setThumbnail("https://cdn.discordapp.com/attachments/959912987987148870/1104817393169088522/airplane_departure.png")
+            .setColor("#ff0000");
+
+        message.channel.send(embed);
+    }
+
+    public onBanCount(message: Discord.Message) {
+        this.banCount(message);
+    }
+}

--- a/src/CommandController.ts
+++ b/src/CommandController.ts
@@ -80,6 +80,7 @@ export interface CommandList {
         endpoint: Command;
         endpoints: Command;
     };
+    banCount: Command;
 }
 
 export default class CommandController {


### PR DESCRIPTION
Since in the server settings you only get a list of banned people, but no counter, I added a command, that shows how many people are banned.

Since I have no local instance of Botty running, I have no idea if this command works, I just tried to recreate https://github.com/Querijn/BottyMcBotface/commit/b5a14a70c96181c7d4dc95b4103ab9d3e677fdbd