### PR TITLE
use channel name or tags to filter `!libs`

### DIFF
--- a/settings/shared_settings.json
+++ b/settings/shared_settings.json
@@ -112,7 +112,7 @@
     },
     "riotApiLibraries": {
         "noLanguage": "No libraries found for language: ",
-        "languageList": "I have libraries for one of the following languages: {languages}\nChoose one you like and reply with `!libs <your language>`.",
+        "languageList": "I have libraries for one of the following languages: {languages}\nChoose one you like and reply with `!libs <your language> <...tags>`.",
         "githubErrorList": "I tried to get the languages from Github, but Github replied with status code ",
         "githubErrorLanguage": "I tried to get the language from Github, but Github replied with status code ",
         "baseURL": "https://api.github.com/repos/WxWatch/riot-api-libraries/contents/libraries/",

--- a/settings/shared_settings.json
+++ b/settings/shared_settings.json
@@ -133,6 +133,21 @@
                 "objc"
             ]
         },
+        "channelTopics": {
+            "lol": [
+                "lol",
+                "v4"
+            ],
+            "lcu": [
+                "lcu"
+            ],
+            "tft": [
+                "tft"
+            ],
+            "lor": [
+                "lor"
+            ]
+        },
         "checkInterval": 10800000
     },
     "autoReact": {

--- a/src/RiotAPILibraries.ts
+++ b/src/RiotAPILibraries.ts
@@ -78,7 +78,7 @@ export default class RiotAPILibraries {
         if ("name" in message.channel) {
             for (const [topic, tags] of Object.entries(this.settings.riotApiLibraries.channelTopics)) {
                 if (message.channel.name.toLowerCase().includes(topic)) {
-                    topics = tags as unknown as string[];
+                    topics = tags
                     break;
                 }
             }

--- a/src/RiotAPILibraries.ts
+++ b/src/RiotAPILibraries.ts
@@ -50,13 +50,6 @@ interface LibraryDescription {
 }
 
 export default class RiotAPILibraries {
-    static CHANNEL_TOPICS = {
-        lol: ["lol", "v4"],
-        lcu: ["lcu"],
-        tft: ["tft"],
-        lor: ["lor"]
-    } as const;
-
     private settings: SharedSettings;
 
     private lastCall: number;
@@ -83,7 +76,7 @@ export default class RiotAPILibraries {
 
         let topics: string[] = ["v4"];
         if ("name" in message.channel) {
-            for (const [topic, tags] of Object.entries(RiotAPILibraries.CHANNEL_TOPICS)) {
+            for (const [topic, tags] of Object.entries(this.settings.riotApiLibraries.channelTopics)) {
                 if (message.channel.name.toLowerCase().includes(topic)) {
                     topics = tags as unknown as string[];
                     break;

--- a/src/RiotAPILibraries.ts
+++ b/src/RiotAPILibraries.ts
@@ -239,7 +239,7 @@ export default class RiotAPILibraries {
         if (Array.isArray(editMessage)) { editMessage = editMessage[0]; }
 
         if (libraryDescriptions.length === 0) {
-            editMessage.edit(`No up-to-date libraries found for ${language}`);
+            editMessage.edit(`No up-to-date libraries found for ${language} tagged with \`${tags.join("\`, \`")}\``);
             return;
         }
 

--- a/src/SharedSettings.ts
+++ b/src/SharedSettings.ts
@@ -124,6 +124,7 @@ export interface SharedSettings {
         githubErrorLanguage: string,
         baseURL: string,
         aliases: { [key: string]: string[] },
+        channelTopics: { [key: string]: string[] },
         checkInterval: number,
     };
 


### PR DESCRIPTION
This should mean when you're in tft-dev and run !libs you get a list of tft libraries. Any extra arguments are appended to the topic list instead of replying with an error.