### PR TITLE
load description from repo

### DIFF
--- a/src/RiotAPILibraries.ts
+++ b/src/RiotAPILibraries.ts
@@ -25,6 +25,7 @@ interface GithubAPIStruct {
 }
 interface GithubAPILibraryStruct {
     stargazers_count: number;
+    description: string;
 }
 
 interface APILibraryLink {
@@ -123,6 +124,10 @@ export default class RiotAPILibraries {
 
         const repoResponse = await repoResponsePromise;
         const repoInfo: GithubAPILibraryStruct = await repoResponse.json();
+
+        if(!libraryInfo.description){
+            libraryInfo.description = repoInfo.description;
+        }
 
         return {
             library: libraryInfo,


### PR DESCRIPTION
I noticed that in `WxWatch/riot-api-libraries` in the readme it is mentioned that if `description` is omitted then the description from the repository is used but I didn't find this function in Boatty. So I am adding it.

NOTE: the code was added without knowledge of TS so someone should check it