### PR TITLE
Change C# color code from "green" to "purple"

### DIFF
--- a/src/RiotAPILibraries.ts
+++ b/src/RiotAPILibraries.ts
@@ -209,7 +209,7 @@ export default class RiotAPILibraries {
             "javascript": 0XF1E05A,
             "typescript": 0X2B7489,
             "python": 0X3572A5,
-            "c-sharp": 0X178600,
+            "c-sharp": 0X7355DD,
             "cpp": 0XF34B7D,
             "c": 0X555555,
             "java": 0XB07219,


### PR DESCRIPTION
A few days ago, GitHub changed the color for C# from green to purple.
<img width="289" height="87" alt="image" src="https://github.com/user-attachments/assets/36c33f5c-35b6-4fb9-a1f6-a7a02db22ec7" />
